### PR TITLE
Abstract driver class

### DIFF
--- a/build-API.sh
+++ b/build-API.sh
@@ -22,6 +22,7 @@ rm include_tmp.h
 
 cat include/functions.h >> gnublin.h
 
+cat drivers/driver.h >> gnublin.h
 cat drivers/gpio.h >> gnublin.h
 cat drivers/i2c.h >> gnublin.h
 cat drivers/spi.h >> gnublin.h
@@ -52,6 +53,7 @@ echo "//********************************************
 
 cat include/functions.cpp >> gnublin.cpp
 
+cat drivers/driver.cpp >> gnublin.cpp
 cat drivers/gpio.cpp >> gnublin.cpp
 cat drivers/i2c.cpp >> gnublin.cpp
 cat drivers/spi.cpp >> gnublin.cpp

--- a/drivers/adc.cpp
+++ b/drivers/adc.cpp
@@ -18,44 +18,8 @@ gnublin_adc::gnublin_adc(){
 		sleep(1);
 	}
 	file.close();
-	error_flag = false;
+	clearError();
 }
-
-//-------------fail-------------
-/** @~english 
-* @brief Returns the error flag. 
-*
-* If something went wrong, the flag is true.
-* @return bool error_flag
-*
-* @~german 
-* @brief Gibt das Error Flag zurück.
-*
-* Falls das Error Flag in der Klasse gesetzt wurde, wird true zurück gegeben, anderenfalls false.
-* @return bool error_flag
-*/
-bool gnublin_adc::fail(){
-	return error_flag;
-}
-
-
-//-------------getErrorMessage-------------
-/** @~english 
-* @brief Get the last Error Message.
-*
-* This Funktion returns the last Error Message, which occurred in that Class.
-* @return ErrorMessage as c-string
-*
-* @~german 
-* @brief Gibt die letzte Error Nachricht zurück.
-*
-* Diese Funktion gibt die Letzte Error Nachricht zurück, welche in dieser Klasse gespeichert wurde.
-* @return ErrorMessage als c-string
-*/
-const char *gnublin_adc::getErrorMessage(){
-	return ErrorMessage.c_str();
-}
-
 
 //-------------getValue-------------
 /** @~english 
@@ -78,16 +42,14 @@ int gnublin_adc::getValue(int pin){
 	std::string pin_str = numberToString(pin);
 	std::string device = "/dev/lpc313x_adc";
 	std::ofstream file(device.c_str());
-	if (file < 0) {
-		error_flag = true;
-		return -1;
-	}
+	if (file < 0) 
+		return setErrorMessage("Unable to open "+device);
 	file << pin_str;
 	file.close();
 	std::ifstream dev_file(device.c_str());
 	dev_file >> value;
 	dev_file.close();
-	error_flag = false;
+	clearError();
 	return hexstringToNumber(value);
 }
 
@@ -126,7 +88,7 @@ int gnublin_adc::getVoltage(int pin){
 * @return Erfolg: 1, Fehler: -1
 */
 int gnublin_adc::setReference(int ref){
-	error_flag = false;
+	clearError();
 	return 1;
 }
 

--- a/drivers/adc.h
+++ b/drivers/adc.h
@@ -15,17 +15,14 @@
 *
 * Mit der gnublin_adc API lassen sich die GPAs auf dem GNUBLIN einfach aus dem eigenem Programm heraus auslesen.  
 */
-class gnublin_adc {
+class gnublin_adc : public gnublin_driver {
 	public:
 		gnublin_adc();
 		int getValue(int pin);
 		int getVoltage(int pin);
 		int setReference(int ref);
-		bool fail();
-		const char *getErrorMessage();
 	private:
-		bool error_flag;
-		std::string ErrorMessage;
+		void onError() {};
 };
 
 #endif

--- a/drivers/driver.cpp
+++ b/drivers/driver.cpp
@@ -1,0 +1,87 @@
+#include "driver.h"
+
+//*******************************************************************
+//Class for accessing GNUBLIN i2c Bus
+//*******************************************************************
+
+//------------------Konstruktor------------------
+/** @~english
+* @brief Sets the error_flag to "false" and the devicefile to "/dev/i2c-1"
+*
+* @~german
+* @brief Setzt das error_flag auf "false" und das devicefile auf standardmäßig "/dev/i2c-1"
+*
+*/
+gnublin_driver::gnublin_driver() 
+{
+	error_flag=false;
+        ErrorMessage="";
+}
+
+//------------------error messaging------------------
+/** @~english
+* @brief Called by the constructors to initialize class variables.
+*
+* @param message String contents that describe the error.
+* @return failure: -1
+*
+* @~german
+* @brief Wird von den Konstruktoren der Klasse Variablen zu initialisieren.
+*
+* @param message String Inhalte, die den Fehler beschreiben.
+* @return failure: -1
+*
+*/
+int gnublin_driver::setErrorMessage(std::string message)
+{
+   ErrorMessage=message;
+   error_flag=true; 
+   return -1; 
+}
+
+//------------------error messaging------------------
+/** @~english
+* @brief Resets the error_flag and other associated details.
+*
+* @~german
+* @brief Setzt die error_flag und anderen damit verbundenen Informationen.
+*
+*/
+void gnublin_driver::clearError()
+{
+   ErrorMessage="";
+   error_flag=false; 
+}
+
+//-------------------------------Fail-------------------------------
+/** @~english 
+* @brief returns the error flag to check if the last operation went wrong
+*
+* @return error_flag as boolean
+*
+* @~german 
+* @brief Gibt das error_flag zurück um zu überprüfen ob die vorangegangene Operation einen Fehler auweist
+*
+* @return error_flag als bool
+*/
+bool gnublin_driver::fail(){
+	return error_flag;
+}
+
+//-------------get Error Message-------------
+/** @~english
+* @brief Get the last Error Message.
+*
+* This function returns the last Error Message, which occurred in that Class.
+* @return ErrorMessage as c-string
+*
+* @~german
+* @brief Gibt die letzte Error Nachricht zurück.
+*
+* Diese Funktion gibt die Letzte Error Nachricht zurück, welche in dieser Klasse gespeichert wurde.
+* @return ErrorMessage als c-string
+*/
+const char *gnublin_driver::getErrorMessage(){
+	return ErrorMessage.c_str();
+}
+

--- a/drivers/driver.h
+++ b/drivers/driver.h
@@ -1,0 +1,28 @@
+#include "../include/includes.h"
+//*******************************************************************
+//Class for accessing GNUBLIN i2c Bus
+//*******************************************************************
+/**
+* @class gnublin_i2c
+* @~english
+* @brief Class for accessing GNUBLIN i2c bus
+*
+* The GNUBLIN I2C bus can easily accessed with this class
+* @~german 
+* @brief Klasse für den zugriff auf den GNUBLIN I2C Bus
+*
+* Die GNUBLIN I2C Klasse gewährt einfachen Zugriff auf den I2C Bus
+*/ 
+
+class gnublin_driver {
+	bool error_flag;
+	std::string ErrorMessage;
+	virtual void onError() = 0;
+protected:
+	gnublin_driver();
+public:
+	bool fail();
+	int setErrorMessage(std::string message);
+	const char *getErrorMessage();
+        void clearError();
+};

--- a/drivers/gpio.h
+++ b/drivers/gpio.h
@@ -1,5 +1,4 @@
 #include "../include/includes.h"
-
 /**
 * @class gnublin_gpio
 * @~english
@@ -11,16 +10,12 @@
 *
 * Mit der gnublin_gpio API lassen sich die GPIO-Ports auf dem GNUBLIN einfach aus dem eigenem Programm heraus ansteuern.  
 */
-class gnublin_gpio {
+class gnublin_gpio : public gnublin_driver {
 	public:
 		gnublin_gpio();
-		bool fail();
 		int pinMode(int pin, std::string direction); //Defines GPIO<pin> as INPUT or OUTPUT
 		int digitalWrite(int pin, int value); //Writes value on GPIO
 		int digitalRead(int pin); //Reads value from GPIO<pin>
 		int unexport(int pin);
-		const char *getErrorMessage();
-	private:
-		bool error_flag;
-		std::string ErrorMessage;
+		void onError() {};
 };

--- a/drivers/i2c.h
+++ b/drivers/i2c.h
@@ -1,4 +1,5 @@
 #include "../include/includes.h"
+#include "driver.h"
 //*******************************************************************
 //Class for accessing GNUBLIN i2c Bus
 //*******************************************************************
@@ -14,25 +15,21 @@
 * Die GNUBLIN I2C Klasse gewährt einfachen Zugriff auf den I2C Bus
 */ 
 
-class gnublin_i2c {
-	bool error_flag;
+class gnublin_i2c : public gnublin_driver {
 	int slave_address;
 	std::string devicefile;
-	std::string ErrorMessage;
 	int fd;
-	int errorMsg(std::string message);
 	int open_fd();
 	void close_fd();
 	void init(std::string DeviceFile, int Address);
+        void onError();
 public:
 	gnublin_i2c();
 	gnublin_i2c(int Address);
 	gnublin_i2c(std::string DeviceFile, int Address);
 	~gnublin_i2c();
-	bool fail();
 	int setAddress(int Address);
 	int getAddress();
-	const char *getErrorMessage();
 	int setDevicefile(std::string filename);
 	int receive(unsigned char *RxBuf, int length);
 	int receive(unsigned char RegisterAddress, unsigned char *RxBuf, int length);

--- a/drivers/spi.cpp
+++ b/drivers/spi.cpp
@@ -1,6 +1,5 @@
 #include "spi.h"
 
-
 //***************************************************************************
 // Class for accessing the SPI-Bus
 //***************************************************************************
@@ -19,8 +18,8 @@
 * GNUBLIN: CS = 11
 * RASPBERRY PI: CS = 0
 */
-gnublin_spi::gnublin_spi(){
-	error_flag = false;
+gnublin_spi::gnublin_spi() : gnublin_driver()
+{
 	#if BOARD == RASPBERRY_PI
 	std::string device = "/dev/spidev0.0";
 	#else
@@ -35,6 +34,8 @@ gnublin_spi::gnublin_spi(){
 		#endif
 		sleep(1);
 		fd = open(device.c_str(), O_RDWR);
+		if (fd < 0)
+			setErrorMessage("Unable to open file "+device+"\n");
 	}
 }
 
@@ -44,41 +45,6 @@ gnublin_spi::gnublin_spi(){
 gnublin_spi::~gnublin_spi(){
 	close(fd);
 }
-
-
-//******************** fail() ***********************************************
-/**
-* @~english
-* @brief Returns the errorflag to detect error in the previous called method.
-*
-* @return error_flag
-*
-* @~german
-* @brief Gibt das errorflag zurück, um Fehler in der zuvor aufgerugfenen Methode zu erkennen.
-*
-* @return error_flag
-*/
-bool gnublin_spi::fail(){
-	return error_flag;
-}
-
-
-//-------------get Error Message-------------
-/**
-* @~english
-* @brief Returns the ErrorMessage of the previous error if one exist.
-*
-* @return ErrorMessage as C-String
-*
-* @~german
-* @brief Gibt die Fehlernachricht des zuvor aufgetretenen Fehlers zurück, wenn weine exisitert.
-*
-* @return ErrorMessage als C-String
-*/
-const char *gnublin_spi::getErrorMessage(){
-	return ErrorMessage.c_str();
-}
-
 
 //*********************** setCS *********************************************
 
@@ -108,12 +74,10 @@ int gnublin_spi::setCS(int cs){
 		system(command.c_str());
 		sleep(1);
 		fd = open(device.c_str(), O_RDWR);
-		if (fd < 0){
-			error_flag = true;
-			return -1;
-		}
+		if (fd < 0)
+		    return setErrorMessage("Unable to open file "+device+"\n");
 	}
-	error_flag = false;
+        clearError();
 	return 1;
 }
 
@@ -134,11 +98,9 @@ int gnublin_spi::setCS(int cs){
 * @return 1 bei Erfolg, -1 im Fehlerfall
 */
 int gnublin_spi::setMode(unsigned char mode){
-	if (ioctl(fd, SPI_IOC_WR_MODE, &mode) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_WR_MODE, &mode) < 0)
+		return setErrorMessage("ioctl failed.");
+        clearError();
 	return 1;
 }
 
@@ -158,11 +120,9 @@ int gnublin_spi::setMode(unsigned char mode){
 */
 int gnublin_spi::getMode(){
 	__u8 mode;
-	if (ioctl(fd, SPI_IOC_RD_MODE, &mode) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_RD_MODE, &mode) < 0)
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return mode;
 }
 
@@ -183,11 +143,9 @@ int gnublin_spi::getMode(){
 * @return 1 bei Erfolg, -1 im Fehlerfall
 */
 int gnublin_spi::setLSB(unsigned char lsb){
-	if (ioctl(fd, SPI_IOC_WR_LSB_FIRST, &lsb) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_WR_LSB_FIRST, &lsb) < 0)
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return 1;
 }
 
@@ -207,11 +165,9 @@ int gnublin_spi::setLSB(unsigned char lsb){
 */
 int gnublin_spi::getLSB(){
 	__u8 lsb;
-	if (ioctl(fd, SPI_IOC_RD_LSB_FIRST, &lsb) < 0) {
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_RD_LSB_FIRST, &lsb) < 0) 
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return lsb;
 }
 
@@ -232,11 +188,9 @@ int gnublin_spi::getLSB(){
 * @return 1 bei Erfolg, -1 im Fehlerfall
 */
 int gnublin_spi::setLength(unsigned char bits){
-	if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits) < 0)
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return 1;
 }
 
@@ -256,11 +210,9 @@ int gnublin_spi::setLength(unsigned char bits){
 */
 int gnublin_spi::getLength(){
 	__u8 bits;
-	if (ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &bits) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &bits) < 0)
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return bits;
 }
 
@@ -281,11 +233,9 @@ int gnublin_spi::getLength(){
 * @return 1 bei Erfolg, -1 im Fehlerfall
 */
 int gnublin_spi::setSpeed(unsigned int speed){
-	if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = true;
+	if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0)
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return 1;
 }
 
@@ -305,11 +255,9 @@ int gnublin_spi::setSpeed(unsigned int speed){
 */
 int gnublin_spi::getSpeed(){
 	__u32 speed;
-	if (ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) < 0)
+		return setErrorMessage("ioctl failed.");
+	clearError();
 	return speed;
 }
 
@@ -331,11 +279,9 @@ int gnublin_spi::getSpeed(){
 * @return 1 bei Erfolg, -1 im Fehlerfall
 */
 int gnublin_spi::receive(char* buffer, int len){
-	if (read(fd, buffer, len) < 0) {
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (read(fd, buffer, len) < 0) 
+		return setErrorMessage("read failed.");
+	clearError();
 	return 1;
 }
 
@@ -366,11 +312,9 @@ int gnublin_spi::send(unsigned char* tx, int length){
 	xfer.speed_hz = 0;
 	xfer.bits_per_word = 0;
 	status = ioctl(fd, SPI_IOC_MESSAGE(1), &xfer);
-	if ( status < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if ( status < 0)
+		return setErrorMessage("ioctl status shows failure.");
+	clearError();
 	return 1;
 }
 
@@ -414,11 +358,9 @@ int gnublin_spi::message(unsigned char* tx, int tx_length, unsigned char* rx, in
 	xfer[1].bits_per_word = 0;
 
 	status = ioctl(fd, SPI_IOC_MESSAGE(2), xfer);
-	if (status < 0){
-		error_flag = true;
-		return -1;
-	}
-	error_flag = false;
+	if (status < 0)
+		return setErrorMessage("ioctl status shows failure.");
+	clearError();
 	return 1;
 }
 

--- a/drivers/spi.h
+++ b/drivers/spi.h
@@ -1,5 +1,5 @@
 #include "../include/includes.h"
-
+#include "driver.h"
 //***************************************************************************
 // Class for accessing the SPI-Bus
 //***************************************************************************
@@ -15,7 +15,7 @@
 *
 * Diese Klasse ermöglicht das Senden und Empfangen von Daten über den SPI-Bus.
 */
-class gnublin_spi{
+class gnublin_spi : gnublin_driver {
 	public:
 		gnublin_spi();
 		~gnublin_spi();
@@ -31,11 +31,7 @@ class gnublin_spi{
 		int send(unsigned char* tx, int length);
 		int setCS(int cs);
 		int message(unsigned char* tx, int tx_length, unsigned char* rx, int rx_length);
-		const char *getErrorMessage();
-		bool fail();
 	private:
 		int fd;
-		bool error_flag;
-		std::string ErrorMessage;
-		
+		void onError() {};	
 };


### PR DESCRIPTION
I've created an abstract class called gnublin_driver.  Currently, I'm only moved the error handling items : error_flag, ErrorMessage, getErrorMessage etc.   This will eliminate duplicate code in each class and allow for faster enhancements.  

The onError() method is provided as pure virtual method from the driver class.  Overloading this method provides a simple way to implement custom functionality per driver type that is automatically executed when the setErrorMessage() method is called.
