### PR TITLE
Use spi-bcm2835, currently RPi default (all models)

### DIFF
--- a/applications/gnublin-clock/gnublin.cpp
+++ b/applications/gnublin-clock/gnublin.cpp
@@ -744,7 +744,7 @@ gnublin_spi::gnublin_spi(){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if BOARD == RASPBERRY_PI
-		system("modprobe spi-bcm2708");
+		system("modprobe spi-bcm2835");
 		#else
 		system("modprobe spidev cs_pin=11");
 		#endif
@@ -816,7 +816,7 @@ int gnublin_spi::setCS(int cs){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if (BOARD == RASPBERRY_PI)
-		std::string command = "modprobe spi-bcm2708 cs_pin=" + cs_str;
+		std::string command = "modprobe spi-bcm2835 cs_pin=" + cs_str;
 		#else
 		std::string command = "modprobe spidev cs_pin=" + cs_str;
 		#endif

--- a/applications/gnublin-noteprinter/gnublin.cpp
+++ b/applications/gnublin-noteprinter/gnublin.cpp
@@ -754,7 +754,7 @@ gnublin_spi::gnublin_spi(){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if BOARD == RASPBERRY_PI
-		system("modprobe spi-bcm2708");
+		system("modprobe spi-bcm2835");
 		#else
 		system("modprobe spidev cs_pin=11");
 		#endif
@@ -826,7 +826,7 @@ int gnublin_spi::setCS(int cs){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if (BOARD == RASPBERRY_PI)
-		std::string command = "modprobe spi-bcm2708 cs_pin=" + cs_str;
+		std::string command = "modprobe spi-bcm2835 cs_pin=" + cs_str;
 		#else
 		std::string command = "modprobe spidev cs_pin=" + cs_str;
 		#endif

--- a/doc/html_de/drivers_2spi_8cpp_source.html
+++ b/doc/html_de/drivers_2spi_8cpp_source.html
@@ -86,7 +86,7 @@ $(document).ready(function(){initNavTree('drivers_2spi_8cpp_source.html','');});
 <div class="line"><a name="l00032"></a><span class="lineno">   32</span>&#160;<span class="preprocessor"></span>    fd = open(device.c_str(), O_RDWR);</div>
 <div class="line"><a name="l00033"></a><span class="lineno">   33</span>&#160;    <span class="keywordflow">if</span> (fd &lt; 0) {</div>
 <div class="line"><a name="l00034"></a><span class="lineno">   34</span>&#160;<span class="preprocessor">        #if BOARD == RASPBERRY_PI</span></div>
-<div class="line"><a name="l00035"></a><span class="lineno">   35</span>&#160;<span class="preprocessor"></span>        system(<span class="stringliteral">&quot;modprobe spi-bcm2708&quot;</span>);</div>
+<div class="line"><a name="l00035"></a><span class="lineno">   35</span>&#160;<span class="preprocessor"></span>        system(<span class="stringliteral">&quot;modprobe spi-bcm2835&quot;</span>);</div>
 <div class="line"><a name="l00036"></a><span class="lineno">   36</span>&#160;<span class="preprocessor">        #else</span></div>
 <div class="line"><a name="l00037"></a><span class="lineno">   37</span>&#160;<span class="preprocessor"></span>        system(<span class="stringliteral">&quot;modprobe spidev cs_pin=11&quot;</span>);</div>
 <div class="line"><a name="l00038"></a><span class="lineno">   38</span>&#160;<span class="preprocessor">        #endif</span></div>
@@ -123,7 +123,7 @@ $(document).ready(function(){initNavTree('drivers_2spi_8cpp_source.html','');});
 <div class="line"><a name="l00104"></a><span class="lineno">  104</span>&#160;    fd = open(device.c_str(), O_RDWR);</div>
 <div class="line"><a name="l00105"></a><span class="lineno">  105</span>&#160;    <span class="keywordflow">if</span> (fd &lt; 0) {</div>
 <div class="line"><a name="l00106"></a><span class="lineno">  106</span>&#160;<span class="preprocessor">        #if (BOARD == RASPBERRY_PI)</span></div>
-<div class="line"><a name="l00107"></a><span class="lineno">  107</span>&#160;<span class="preprocessor"></span>        std::string command = <span class="stringliteral">&quot;modprobe spi-bcm2708 cs_pin=&quot;</span> + cs_str;</div>
+<div class="line"><a name="l00107"></a><span class="lineno">  107</span>&#160;<span class="preprocessor"></span>        std::string command = <span class="stringliteral">&quot;modprobe spi-bcm2835 cs_pin=&quot;</span> + cs_str;</div>
 <div class="line"><a name="l00108"></a><span class="lineno">  108</span>&#160;<span class="preprocessor">        #else</span></div>
 <div class="line"><a name="l00109"></a><span class="lineno">  109</span>&#160;<span class="preprocessor"></span>        std::string command = <span class="stringliteral">&quot;modprobe spidev cs_pin=&quot;</span> + cs_str;</div>
 <div class="line"><a name="l00110"></a><span class="lineno">  110</span>&#160;<span class="preprocessor">        #endif</span></div>

--- a/doc/html_en/drivers_2spi_8cpp_source.html
+++ b/doc/html_en/drivers_2spi_8cpp_source.html
@@ -86,7 +86,7 @@ $(document).ready(function(){initNavTree('drivers_2spi_8cpp_source.html','');});
 <div class="line"><a name="l00032"></a><span class="lineno">   32</span>&#160;<span class="preprocessor"></span>    fd = open(device.c_str(), O_RDWR);</div>
 <div class="line"><a name="l00033"></a><span class="lineno">   33</span>&#160;    <span class="keywordflow">if</span> (fd &lt; 0) {</div>
 <div class="line"><a name="l00034"></a><span class="lineno">   34</span>&#160;<span class="preprocessor">        #if BOARD == RASPBERRY_PI</span></div>
-<div class="line"><a name="l00035"></a><span class="lineno">   35</span>&#160;<span class="preprocessor"></span>        system(<span class="stringliteral">&quot;modprobe spi-bcm2708&quot;</span>);</div>
+<div class="line"><a name="l00035"></a><span class="lineno">   35</span>&#160;<span class="preprocessor"></span>        system(<span class="stringliteral">&quot;modprobe spi-bcm2835&quot;</span>);</div>
 <div class="line"><a name="l00036"></a><span class="lineno">   36</span>&#160;<span class="preprocessor">        #else</span></div>
 <div class="line"><a name="l00037"></a><span class="lineno">   37</span>&#160;<span class="preprocessor"></span>        system(<span class="stringliteral">&quot;modprobe spidev cs_pin=11&quot;</span>);</div>
 <div class="line"><a name="l00038"></a><span class="lineno">   38</span>&#160;<span class="preprocessor">        #endif</span></div>
@@ -123,7 +123,7 @@ $(document).ready(function(){initNavTree('drivers_2spi_8cpp_source.html','');});
 <div class="line"><a name="l00104"></a><span class="lineno">  104</span>&#160;    fd = open(device.c_str(), O_RDWR);</div>
 <div class="line"><a name="l00105"></a><span class="lineno">  105</span>&#160;    <span class="keywordflow">if</span> (fd &lt; 0) {</div>
 <div class="line"><a name="l00106"></a><span class="lineno">  106</span>&#160;<span class="preprocessor">        #if (BOARD == RASPBERRY_PI)</span></div>
-<div class="line"><a name="l00107"></a><span class="lineno">  107</span>&#160;<span class="preprocessor"></span>        std::string command = <span class="stringliteral">&quot;modprobe spi-bcm2708 cs_pin=&quot;</span> + cs_str;</div>
+<div class="line"><a name="l00107"></a><span class="lineno">  107</span>&#160;<span class="preprocessor"></span>        std::string command = <span class="stringliteral">&quot;modprobe spi-bcm2835 cs_pin=&quot;</span> + cs_str;</div>
 <div class="line"><a name="l00108"></a><span class="lineno">  108</span>&#160;<span class="preprocessor">        #else</span></div>
 <div class="line"><a name="l00109"></a><span class="lineno">  109</span>&#160;<span class="preprocessor"></span>        std::string command = <span class="stringliteral">&quot;modprobe spidev cs_pin=&quot;</span> + cs_str;</div>
 <div class="line"><a name="l00110"></a><span class="lineno">  110</span>&#160;<span class="preprocessor">        #endif</span></div>

--- a/drivers/spi.cpp
+++ b/drivers/spi.cpp
@@ -32,7 +32,7 @@ gnublin_spi::gnublin_spi(){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if BOARD == RASPBERRY_PI
-		system("modprobe spi-bcm2708");
+		system("modprobe spi-bcm2835");
 		#else
 		system("modprobe spidev cs_pin=11");
 		#endif
@@ -104,7 +104,7 @@ int gnublin_spi::setCS(int cs){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if (BOARD == RASPBERRY_PI)
-		std::string command = "modprobe spi-bcm2708 cs_pin=" + cs_str;
+		std::string command = "modprobe spi-bcm2835 cs_pin=" + cs_str;
 		#else
 		std::string command = "modprobe spidev cs_pin=" + cs_str;
 		#endif

--- a/gnublin.cpp
+++ b/gnublin.cpp
@@ -757,7 +757,7 @@ gnublin_spi::gnublin_spi(){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if BOARD == RASPBERRY_PI
-		system("modprobe spi-bcm2708");
+		system("modprobe spi-bcm2835");
 		#else
 		system("modprobe spidev cs_pin=11");
 		#endif
@@ -829,7 +829,7 @@ int gnublin_spi::setCS(int cs){
 	fd = open(device.c_str(), O_RDWR);
 	if (fd < 0) {
 		#if (BOARD == RASPBERRY_PI)
-		std::string command = "modprobe spi-bcm2708 cs_pin=" + cs_str;
+		std::string command = "modprobe spi-bcm2835 cs_pin=" + cs_str;
 		#else
 		std::string command = "modprobe spidev cs_pin=" + cs_str;
 		#endif


### PR DESCRIPTION
Changed references for the Raspberry Pi SPI kernel module from spi-bcm2708 to spi-bcm2835 as the old module is deprecated in favor of the new module: https://github.com/notro/spi-bcm2708/wiki